### PR TITLE
fix: rename perv to prev for wrong abbreviation

### DIFF
--- a/src/devtools/components/FieldState.tsx
+++ b/src/devtools/components/FieldState.tsx
@@ -32,7 +32,7 @@ const FieldState: React.FC<FieldStateProps> = ({
         <div className={styles.actions}>
           <Button
             className={clsx(styles.button, styles.collapseButton)}
-            onClick={() => setIsCollapsed((perv) => !perv)}
+            onClick={() => setIsCollapsed((prev) => !prev)}
           >
             {isCollapsed ? '+' : '-'}
           </Button>

--- a/src/devtools/components/FormState.tsx
+++ b/src/devtools/components/FormState.tsx
@@ -19,7 +19,7 @@ const FormState: React.FC<{
       )}
       <Button
         className={styles.button}
-        onClick={() => setIsCollapsed((perv) => !perv)}
+        onClick={() => setIsCollapsed((prev) => !prev)}
       >
         <span
           style={{ color: state.valid ? '#1bda2b' : '#ec5990', fontSize: 18 }}


### PR DESCRIPTION
The abbreviation for previous should be prev